### PR TITLE
v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 C# color helpers - color blender.
 
+> What's the resulting color of #AABBCC with 70% opacity on a white background?
+
+**That's what this library is for!**
+
 ## Nuget
 
 [![Nuget](https://img.shields.io/nuget/v/Divis.DarkColors?label=Divis.DarkColors)](https://www.nuget.org/packages/Divis.DarkColors/)

--- a/README.md
+++ b/README.md
@@ -22,19 +22,24 @@ Blend multiple colors together with transparency support.
 
 ### Basic
 ```csharp
-var baseColor = Color.FromArgb(0, 0, 0); //The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+//The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+var baseColor = Color.FromArgb(0, 0, 0); 
 
-var colorToAdd = Color.FromArgb(125, 55, 13); //A color to add. This one can have transparency.
+//A color to add. This one can have transparency.
+var colorToAdd = Color.FromArgb(125, 55, 13); 
 
 var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
 ```
 
 ### Advanced
 ```csharp
-var baseColor = Color.FromArgb(0, 0, 0); //The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+//The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+var baseColor = Color.FromArgb(0, 0, 0); 
 
-var colorToAdd = Color.FromArgb(127, 125, 55, 13); //A color to add. This one can have transparency.
-var colorToAddLayer = new ColorLayer(colorToAdd, 50); //The color's amount is set to 50% and it's alpha channel is at 50% so in the result, only 25% of this color will be added on top of the base color.
+//A color to add. This one can have transparency.
+var colorToAdd = Color.FromArgb(127, 125, 55, 13); 
+//The color's amount is set to 50% and it's alpha channel is at 50% so in the result, only 25% of this color will be added on top of the base color.
+var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
 
 var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAddLayer);
 
@@ -49,7 +54,8 @@ var threeColorsCombined = ColorBlender.Combine(baseColor, colorToAddLayer, anoth
 Using the `Color`'s alpha channel:
 ```csharp
 var baseColor = Color.FromArgb(0, 0, 0);
-var colorToAdd = Color.FromArgb(127, 125, 55, 13); //set 50% transparency using the color Alpha channel
+//set 50% transparency using the color Alpha channel
+var colorToAdd = Color.FromArgb(127, 125, 55, 13);
 var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
 ```
 
@@ -57,15 +63,18 @@ Using the `ColorLayer`'s `AmountPercentage` property:
 ```csharp
 var baseColor = Color.FromArgb(0, 0, 0);
 var colorToAdd = Color.FromArgb(125, 55, 13);
-var colorToAddLayer = new ColorLayer(colorToAdd, 50); //set 50% transparency using the color AmountPercentage property of the ColorLayer
+//set 50% transparency using the color AmountPercentage property of the ColorLayer
+var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
 var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
 ```
 
 Using both the `Color`'s alpha channel and `ColorLayer`'s `AmountPercentage` property:
 ```csharp
 var baseColor = Color.FromArgb(0, 0, 0);
-var colorToAdd = Color.FromArgb(127, 125, 55, 13); //set 50% transparency using the color Alpha channel
-var colorToAddLayer = new ColorLayer(colorToAdd, 50); //set 50% transparency using the color AmountPercentage property of the ColorLayer. The resulting color will only be added by 25% because both color's Alpha and layer's AmountPercentage were used.
+//set 50% transparency using the color Alpha channel
+var colorToAdd = Color.FromArgb(127, 125, 55, 13); 
+//set 50% transparency using the color AmountPercentage property of the ColorLayer. The resulting color will only be added by 25% because both color's Alpha and layer's AmountPercentage were used.
+var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
 var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
 ```
 

--- a/sample/SampleApp/MainViewModel.cs
+++ b/sample/SampleApp/MainViewModel.cs
@@ -38,19 +38,24 @@ public class MainViewModel
 
     private void SimpleExample()
     {
-        var baseColor = Color.FromArgb(0, 0, 0); //The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+        //The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+        var baseColor = Color.FromArgb(0, 0, 0);
 
-        var colorToAdd = Color.FromArgb(125, 55, 13); //A color to add. This one can have transparency.
+        //A color to add. This one can have transparency.
+        var colorToAdd = Color.FromArgb(125, 55, 13);
 
         var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
     }
 
     private void AdvancedExample()
     {
-        var baseColor = Color.FromArgb(0, 0, 0); //The base color. This one can't be transparent. If it is, the alpha channel will be ignored.
+        // The base color.This one can't be transparent. If it is, the alpha channel will be ignored.
+        var baseColor = Color.FromArgb(0, 0, 0);
 
-        var colorToAdd = Color.FromArgb(127, 125, 55, 13); //A color to add. This one can have transparency.
-        var colorToAddLayer = new ColorLayer(colorToAdd, 50); //The color's amount is set to 50% and it's alpha channel is at 50% so in the result, only 25% of this color will be added on top of the base color.
+        //A color to add. This one can have transparency.
+        var colorToAdd = Color.FromArgb(127, 125, 55, 13);
+        //The color's amount is set to 50% and it's alpha channel is at 50% so in the result, only 25% of this color will be added on top of the base color.
+        var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
 
         var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAddLayer);
 
@@ -63,7 +68,8 @@ public class MainViewModel
     private void TransparencyUsingAlphaExample()
     {
         var baseColor = Color.FromArgb(0, 0, 0);
-        var colorToAdd = Color.FromArgb(127, 125, 55, 13); //set 50% transparency using the color Alpha channel
+        //set 50% transparency using the color Alpha channel
+        var colorToAdd = Color.FromArgb(127, 125, 55, 13); 
         var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
     }
 
@@ -71,15 +77,18 @@ public class MainViewModel
     {
         var baseColor = Color.FromArgb(0, 0, 0);
         var colorToAdd = Color.FromArgb(125, 55, 13);
-        var colorToAddLayer = new ColorLayer(colorToAdd, 50); //set 50% transparency using the color AmountPercentage property of the ColorLayer
+        //set 50% transparency using the color AmountPercentage property of the ColorLayer
+        var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
         var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
     }
 
     private void TransparencyUsingAlphaAndAmountExample()
     {
         var baseColor = Color.FromArgb(0, 0, 0);
-        var colorToAdd = Color.FromArgb(127, 125, 55, 13); //set 50% transparency using the color Alpha channel
-        var colorToAddLayer = new ColorLayer(colorToAdd, 50); //set 50% transparency using the color AmountPercentage property of the ColorLayer. The resulting color will only be added by 25% because both color's Alpha and layer's AmountPercentage were used.
+        //set 50% transparency using the color Alpha channel
+        var colorToAdd = Color.FromArgb(127, 125, 55, 13);
+        //set 50% transparency using the color AmountPercentage property of the ColorLayer. The resulting color will only be added by 25% because both color's Alpha and layer's AmountPercentage were used.
+        var colorToAddLayer = new ColorLayer(colorToAdd, 50); 
         var twoColorsCombined = ColorBlender.Combine(baseColor, colorToAdd);
     }
 

--- a/src/DarkColors/ColorBlender.cs
+++ b/src/DarkColors/ColorBlender.cs
@@ -19,7 +19,7 @@ public static class ColorBlender
 
         foreach (var color in colors)
         {
-            result = Blend(result, color, 100);
+            result = Blend(result, color);
         }
 
         return result;
@@ -33,7 +33,7 @@ public static class ColorBlender
     /// <returns>Color blending result</returns>
     public static Color Combine(Color nonTransparentBase, Color color)
     {
-        return Blend(nonTransparentBase, color, 100);
+        return Blend(nonTransparentBase, color);
     }
 
     /// <summary>
@@ -67,8 +67,13 @@ public static class ColorBlender
         return Blend(nonTransparentBase, layer.Color, amount);
     }
 
-    private static Color Blend(Color source, Color added, double addedManualAmount)
+    private static Color Blend(Color source, Color added, double addedManualAmount = 1d)
     {
+        if(addedManualAmount < 0d || addedManualAmount > 1d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(addedManualAmount), addedManualAmount, "Amount has to be in range 0-1");
+        }
+
         var addedTransparencyAmount = (double)added.A / 255;
         var addedAmount = addedManualAmount * addedTransparencyAmount;
         var r = BlendChannel(source.R, added.R, addedAmount);

--- a/src/DarkColors/DarkColors.csproj
+++ b/src/DarkColors/DarkColors.csproj
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Divis.DarkColors</PackageId>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>michaldivis</Authors>
 		<Company>Michal Diviš</Company>
 		<Product>Dark Colors</Product>

--- a/tests/DarkColorsTests/ColorBlenderTests.cs
+++ b/tests/DarkColorsTests/ColorBlenderTests.cs
@@ -9,7 +9,7 @@ public class ColorBlenderTests
     [InlineData(25, "#10153c")]
     [InlineData(65, "#29389e")]
     [InlineData(100, "#4056F4")]
-    public void Combine_ShouldWork_WhenAddingSingeNonTransparentColor(int percentage, string expectedHex)
+    public void CombineWithLayers_ShouldWork_WhenAddingSingeNonTransparentColor(int percentage, string expectedHex)
     {
         var result = ColorBlender.Combine(Hex("#000"), new ColorLayer[]
         {
@@ -23,7 +23,7 @@ public class ColorBlenderTests
     [InlineData(25, "#080b1f")]
     [InlineData(65, "#151c4f")]
     [InlineData(100, "#202b7a")]
-    public void Combine_ShouldWork_WhenAddingSingeTransparentColor(int percentage, string expectedHex)
+    public void CombineWithLayers_ShouldWork_WhenAddingSingeTransparentColor(int percentage, string expectedHex)
     {
         var result = ColorBlender.Combine(Hex("#000"), new ColorLayer[]
         {
@@ -33,7 +33,7 @@ public class ColorBlenderTests
     }
 
     [Fact]
-    public void Combine_ShouldWork_WhenAddingMultipleNonTransparentColors()
+    public void CombineWithLayers_ShouldWork_WhenAddingMultipleNonTransparentColors()
     {
         var result = ColorBlender.Combine(Hex("#000"), new ColorLayer[]
         {
@@ -44,7 +44,7 @@ public class ColorBlenderTests
     }
 
     [Fact]
-    public void Combine_ShouldWork_WhenAddingMultipleTransparentColors()
+    public void CombineWithLayers_ShouldWork_WhenAddingMultipleTransparentColors()
     {
         var result = ColorBlender.Combine(Hex("#000"), new ColorLayer[]
         {
@@ -52,6 +52,24 @@ public class ColorBlenderTests
             new(Hex("#5CB1740F"), 55) //#B1740F with 36% transparency
         });
         AssertColorsMatch(result, Hex("#2b2121"));
+    }
+
+    [Theory]
+    [InlineData("#004056F4", "#000")] //0%
+    [InlineData("#404056F4", "#10153c")] //25%
+    [InlineData("#A64056F4", "#29389e")] //65%
+    [InlineData("#FF4056F4", "#4056F4")] //100%
+    public void CombineWithColors_ShouldWork_WhenAddingSingeColor(string inputHex, string expectedHex)
+    {
+        var result = ColorBlender.Combine(Hex("#000"), Hex(inputHex));
+        AssertColorsMatch(result, Hex(expectedHex));
+    }
+
+    [Fact]
+    public void CombineWithColors_ShouldWork_WhenAddingMultipleColors()
+    {
+        var result = ColorBlender.Combine(Hex("#000"), Hex("#634056F4"), Hex("#40B1740F"));
+        AssertColorsMatch(result, Hex("#3f364b"));
     }
 
     private static void AssertColorsMatch(Color actual, Color expected)


### PR DESCRIPTION
# Fixes
Fixed: `Combine` overrides that take a `Color` or `params Color[]` throw exception because the amount used in passed in percent instead of 0-1